### PR TITLE
WIP: Interface for building Monte Carlo experiments

### DIFF
--- a/src/DiffEqMonteCarlo.jl
+++ b/src/DiffEqMonteCarlo.jl
@@ -2,63 +2,9 @@ module DiffEqMonteCarlo
 
 using DiffEqBase, RecipesBase
 
-type MonteCarloTestSimulation{S,T} <: AbstractMonteCarloSimulation
-  solution_data::S
-  errors::Dict{Symbol,Vector{T}}
-  error_means::Dict{Symbol,T}
-  error_medians::Dict{Symbol,T}
-  elapsedTime::Float64
-end
-
-type MonteCarloSimulation{T} <: AbstractMonteCarloSimulation
-  solution_data::Vector{T}
-  elapsedTime::Float64
-end
-
-"""
-`monte_carlo_simulation(prob::DEProblem,alg)`
-
-Performs a parallel Monte-Carlo simulation to solve the DEProblem numMonte times.
-Returns a vector of solution objects.
-
-### Keyword Arguments
-* `numMonte` - Number of Monte-Carlo simulations to run. Default is 10000
-* `save_timeseries` - Denotes whether save_timeseries should be turned on in each run. Default is false.
-* `kwargs...` - These are common solver arguments which are then passed to the solve method
-"""
-function calculate_sim_errors(sim::MonteCarloSimulation)
-  solution_data = sim.solution_data
-  errors = Dict{Symbol,Vector{eltype(solution_data[1].u[1])}}() #Should add type information
-  error_means  = Dict{Symbol,eltype(solution_data[1].u[1])}()
-  error_medians= Dict{Symbol,eltype(solution_data[1].u[1])}()
-  for k in keys(solution_data[1].errors)
-    errors[k] = [sol.errors[k] for sol in solution_data]
-    error_means[k] = mean(errors[k])
-    error_medians[k]=median(errors[k])
-  end
-  return MonteCarloTestSimulation(solution_data,errors,error_means,error_medians,sim.elapsedTime)
-end
-
-function monte_carlo_simulation(prob::DEProblem,alg;output_func = identity,prob_func=identity,num_monte=10000,kwargs...)
-  elapsedTime = @elapsed solution_data = pmap((i)-> begin
-    new_prob = prob_func(deepcopy(prob))
-    output_func(solve(new_prob,alg;kwargs...))
-  end,1:num_monte)
-  solution_data = convert(Array{typeof(solution_data[1])},solution_data)
-  return(MonteCarloSimulation(solution_data,elapsedTime))
-end
-
-Base.length(sim::AbstractMonteCarloSimulation) = length(sim.solution_data)
-Base.endof( sim::AbstractMonteCarloSimulation) = length(sim)
-Base.getindex(sim::AbstractMonteCarloSimulation,i::Int) = sim.solution_data[i]
-Base.getindex(sim::AbstractMonteCarloSimulation,i::Int,I::Int...) = sim.solution_data[i][I...]
-Base.size(sim::AbstractMonteCarloSimulation) = (length(sim),)
-Base.start(sim::AbstractMonteCarloSimulation) = 1
-function Base.next(sim::AbstractMonteCarloSimulation,state)
-  state += 1
-  (sim[state],state)
-end
-Base.done(sim::AbstractMonteCarloSimulation,state) = state >= length(sim)
+include("experiment.jl")
+include("estimators.jl")
+include("montecarlo.jl")
 
 @recipe function f(sim::AbstractMonteCarloSimulation)
 
@@ -73,5 +19,9 @@ end
 export monte_carlo_simulation, calculate_sim_errors
 
 export MonteCarloSimulation, MonteCarloTestSimulation
+
+export MonteCarloEstimator, ParallelCrude, SerialCrude
+
+export MonteCarloExperiment
 
 end # module

--- a/src/estimators.jl
+++ b/src/estimators.jl
@@ -1,0 +1,4 @@
+abstract MonteCarloEstimator
+
+immutable ParallelCrude <: MonteCarloEstimator end
+immutable SerialCrude <: MonteCarloEstimator end

--- a/src/experiment.jl
+++ b/src/experiment.jl
@@ -1,0 +1,18 @@
+type MonteCarloExperiment{S,F1,F2,F3,J}
+  prob::S
+  output_func::F1
+  prob_func::F2
+  end_condition::F3
+  path_alg::J
+end
+
+function MonteCarloExperiment(prob::DEProblem,output_func,prob_func,end_condition,path_alg)
+   MonteCarloExperiment{typeof(prob),typeof(output_func),
+   typeof(prob_func),typeof(end_condition),typeof(path_alg)}(prob,output_func,prob_func,end_condition,path_alg)
+end
+
+# MonteCarloExperiment(prob::DEProblem,estimator::MonteCarloEstimator) =  MonteCarloExperiment(prob,estimator,
+#      identity,identity,(solution_data)->false,1000)
+#
+# MonteCarloExperiment(prob::DEProblem,estimator::MonteCarloEstimator) =  MonteCarloExperiment(prob,estimator,
+#         identity,identity,(solution_data)->false,1000)

--- a/src/montecarlo.jl
+++ b/src/montecarlo.jl
@@ -1,0 +1,97 @@
+type MonteCarloTestSimulation{S,T} <: AbstractMonteCarloSimulation
+  experiment::MonteCarloExperiment
+  solution_data::S
+  errors::Dict{Symbol,Vector{T}}
+  error_means::Dict{Symbol,T}
+  error_medians::Dict{Symbol,T}
+  elapsedTime::Float64
+  converged::Bool
+end
+
+type MonteCarloSimulation{T} <: AbstractMonteCarloSimulation
+  experiment::MonteCarloExperiment
+  solution_data::Vector{T}
+  elapsedTime::Float64
+  converged::Bool
+end
+
+
+"""
+`monte_carlo_simulation(prob::DEProblem,alg)`
+
+Performs a parallel Monte-Carlo simulation to solve the DEProblem numMonte times.
+Returns a vector of solution objects.
+
+### Keyword Arguments
+* `numMonte` - Number of Monte-Carlo simulations to run. Default is 10000
+* `save_timeseries` - Denotes whether save_timeseries should be turned on in each run. Default is false.
+* `kwargs...` - These are common solver arguments which are then passed to the solve method
+"""
+function calculate_sim_errors(sim::MonteCarloSimulation)
+  solution_data = sim.solution_data
+  errors = Dict{Symbol,Vector{eltype(solution_data[1].u[1])}}() #Should add type information
+  error_means  = Dict{Symbol,eltype(solution_data[1].u[1])}()
+  error_medians= Dict{Symbol,eltype(solution_data[1].u[1])}()
+  for k in keys(solution_data[1].errors)
+    errors[k] = [sol.errors[k] for sol in solution_data]
+    error_means[k] = mean(errors[k])
+    error_medians[k]=median(errors[k])
+  end
+  return MonteCarloTestSimulation(sim.experiment,solution_data,errors,error_means,error_medians,sim.elapsedTime,sim.converged)
+end
+
+
+function monte_carlo_simulation(experiment::MonteCarloExperiment,estimator::ParallelCrude; start_check = 10,max_samples=10000,kwargs ...)
+  prob = experiment.prob
+  prob_func = experiment.prob_func
+  output_func = experiment.output_func
+  alg = experiment.path_alg
+  elapsedTime = @elapsed solution_data = pmap((i)-> begin
+    new_prob = prob_func(deepcopy(prob))
+    output_func(solve(new_prob,alg;kwargs...))
+  end,1:max_samples)
+  solution_data = convert(Array{typeof(solution_data[1])},solution_data)
+  return(MonteCarloSimulation(experiment,solution_data,elapsedTime,false))
+end
+
+function monte_carlo_simulation(experiment::MonteCarloExperiment,estimator::SerialCrude;start_check = 10,max_samples=10000,kwargs ...)
+  prob = experiment.prob
+  alg = experiment.path_alg
+  prob_func = experiment.prob_func
+  output_func = experiment.output_func
+  end_condition = experiment.end_condition
+  # generate one sample so that we know type of solution_data
+  solution_data = []
+  new_prob = prob_func(deepcopy(prob))
+  push!(solution_data,output_func(solve(new_prob,alg;kwargs...)))
+  solution_data = convert(Array{typeof(solution_data[1])},solution_data)
+  # perform monte carlo sims
+  converged = false
+  elapsedTime = @elapsed for i=1:max_samples
+    new_prob = prob_func(deepcopy(prob))
+    push!(solution_data,output_func(solve(new_prob,alg;kwargs...)))
+    if end_condition(solution_data) && i>start_check
+      converged = true
+      break
+    end
+  end
+  return(MonteCarloSimulation(experiment,solution_data,elapsedTime,converged))
+end
+
+function monte_carlo_simulation(prob::DEProblem,alg;output_func = identity,prob_func=identity,start_check=10,max_samples=10000,kwargs...)
+  end_condition =  (x)->false
+  experiment  = MonteCarloExperiment(prob,output_func,prob_func,end_condition,alg)
+  monte_carlo_simulation(experiment,ParallelCrude(),max_samples = 10000;kwargs ...)
+end
+
+Base.length(sim::AbstractMonteCarloSimulation) = length(sim.solution_data)
+Base.endof( sim::AbstractMonteCarloSimulation) = length(sim)
+Base.getindex(sim::AbstractMonteCarloSimulation,i::Int) = sim.solution_data[i]
+Base.getindex(sim::AbstractMonteCarloSimulation,i::Int,I::Int...) = sim.solution_data[i][I...]
+Base.size(sim::AbstractMonteCarloSimulation) = (length(sim),)
+Base.start(sim::AbstractMonteCarloSimulation) = 1
+function Base.next(sim::AbstractMonteCarloSimulation,state)
+  state += 1
+  (sim[state],state)
+end
+Base.done(sim::AbstractMonteCarloSimulation,state) = state >= length(sim)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,24 +3,29 @@ using Base.Test
 
 
 prob = prob_sde_2Dlinear
-sim = monte_carlo_simulation(prob,SRIW1(),dt=1//2^(3),num_monte=10)
+sim = monte_carlo_simulation(prob,SRIW1(),dt=1//2^(3),max_samples=10)
 calculate_sim_errors(sim)
 
 prob = prob_sde_additivesystem
-sim = monte_carlo_simulation(prob,SRA1(),dt=1//2^(3),num_monte=10)
-calculate_sim_errors(sim)
-
-output_func = function (x)
-  last(last(x))^2
+output_func = function (sol)
+  sol.u[end]
 end
-sim = monte_carlo_simulation(prob,SRA1(),output_func=output_func,dt=1//2^(3),num_monte=10)
+end_condition = function (solution_data)
+  std(solution_data[1])/length(solution_data[1])<1.
+end
+experiment = MonteCarloExperiment(prob,output_func,identity,end_condition,SRA1())
+sim = monte_carlo_simulation(experiment,SerialCrude(),dt=1//2^(3),max_samples=50)
 
-prob = prob_sde_lorenz
-sim = monte_carlo_simulation(prob,SRIW1(),dt=1//2^(3),num_monte=10)
-
+#prob = prob_sde_lorenz
+#sim = monte_carlo_simulation(prob,SRIW1(),dt=1//2^(3),max_samples=10)
+#
 prob = prob_ode_linear
 prob_func = function (prob)
   prob.u0 = rand()*prob.u0
   prob
 end
-sim = monte_carlo_simulation(prob,Tsit5(),prob_func = prob_func,num_monte=100)
+end_condition = function (solution_data)
+  false
+end
+experiment = MonteCarloExperiment(prob,output_func,prob_func,end_condition,Tsit5())
+sim = monte_carlo_simulation(experiment,SerialCrude(),dt=1//2^(3),max_samples=10)


### PR DESCRIPTION
I've added a new interface for building and performing Monte Carlo experiments. The goal is to make it easier for people to develop and compare different Monte Carlo estimators. Hopefully this is fairly intuitive to someone who is already familiar with DifferentialEquations.jl. Roughly, `MonteCarloExperiment` contains information about the experiment, while a `MonteCarloEstimator` tells `monte_carlo_simulation` how to carry out the experiment. 