### PR TITLE
Add a test for using user-defined structs in output_func

### DIFF
--- a/test/monte.jl
+++ b/test/monte.jl
@@ -89,3 +89,11 @@ prob2 = MonteCarloProblem(prob,prob_func=prob_func,output_func=output_func,reduc
 sim2 = solve(prob2,Tsit5(),num_monte=100,batch_size=20)
 @test sim2.converged == false
 @test mean(sim.u) ≈ sim2.u/100
+
+immutable SomeUserType end
+output_func = function (sol,i)
+    SomeUserType()
+end
+prob2 = MonteCarloProblem(prob,prob_func=prob_func,output_func=output_func)
+sim2 = solve(prob2,Tsit5(),num_monte=2)
+@test !sim2.converged && typeof(sim2.u) == Vector{SomeUserType}


### PR DESCRIPTION
Requires https://github.com/JuliaDiffEq/DiffEqBase.jl/commit/ece27e47bb62f262e5f8c193fc32207aaa95fde2 in DiffEqBase, so make sure not to tag this before DiffEqBase or the test won't pass.