### PR TITLE
Fix https://github.com/JuliaDiffEq/DiffEqMonteCarlo.jl/issues/31

### DIFF
--- a/src/solve.jl
+++ b/src/solve.jl
@@ -131,10 +131,10 @@ function solve_batch(prob,alg,parallel_type,I,pmap_batch_size,kwargs...)
 
   elseif parallel_type == :threads
     batch_data = Vector{Any}(undef,length(I))
-    Threads.@threads for i in I
+    Threads.@threads for batch_idx in axes(batch_data, 1)
+        i = I[batch_idx]
         iter = 1
         new_prob = prob.prob_func(deepcopy(prob.prob),i,iter)
-        rerun = true
         x = prob.output_func(solve(new_prob,alg;kwargs...),i)
         if !(typeof(x) <: Tuple)
             warn("output_func should return (out,rerun). See docs for updated details")
@@ -155,7 +155,7 @@ function solve_batch(prob,alg,parallel_type,I,pmap_batch_size,kwargs...)
             end
             rerun = _x[2]
         end
-        batch_data[i] = _x[1]
+        batch_data[batch_idx] = _x[1]
     end
     _batch_data = convert(Array{typeof(batch_data[1])},batch_data)
 


### PR DESCRIPTION
I just ran into https://github.com/JuliaDiffEq/DiffEqMonteCarlo.jl/issues/31. The problem is that if `I = 2:2`, then `batch_data` is of length 1 but `i = 2`, and hence the indexing operation `batch_data[i]` in line https://github.com/JuliaDiffEq/DiffEqMonteCarlo.jl/blob/master/src/solve.jl#L158 fails.