### PR TITLE
Fix Distributions Warning

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,7 @@ DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 julia = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,7 @@ version = "v0.15.0"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
-Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
+Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 

--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "v0.15.0"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
+Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 


### PR DESCRIPTION
Fixes warning - 
```
┌ Warning: Package DiffEqMonteCarlo does not have Distributed in its dependencies:
│ - If you have DiffEqMonteCarlo checked out for development and have
│   added Distributed as a dependency but haven't updated your primary
│   environment's manifest file, try `Pkg.resolve()`.
│ - Otherwise you may need to report an issue with DiffEqMonteCarlo
└ Loading Distributed into DiffEqMonteCarlo from project dependency, future warnings for DiffEqMonteCarlo are suppressed.
```